### PR TITLE
Updated gitignore to no longer commit .mono folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin
 obj
+.mono


### PR DESCRIPTION
Updated .gitignore to ignore the .mono folder as it is being created bu the C# Dev Kit extension in VSCode:

https://github.com/microsoft/vscode-dotnettools/issues/985#issuecomment-2015140929